### PR TITLE
Ensure `decoder.decode` handle cases where the input ends in the middle of non-English character

### DIFF
--- a/app/v1/chat/completions/route.ts
+++ b/app/v1/chat/completions/route.ts
@@ -67,7 +67,7 @@ async function chat(apiKey: string, body: any) {
             if (done) {
               controller.close()
             }
-            let data = decoder.decode(value)
+            let data = decoder.decode(value, { stream: true })
             if (isFirstEventData) {
               isFirstEventData = false
               if (shouldRetry(data)) {


### PR DESCRIPTION
Ensure that the decoder.decode function can properly handle instances where the input stream ends mid-way through a multi-byte, non-English character. For more details, refer to the discussion at [Issue #184 on the encoding GitHub page](https://github.com/whatwg/encoding/issues/184#issuecomment-527733881).